### PR TITLE
Fix/getting started cleanup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,10 +1,10 @@
 name: Cypress Tests
 
-on: push
+on: pull_request
 
 jobs:
   cypress-run:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -12,6 +12,3 @@ jobs:
       # and run all Cypress tests
       - name: Cypress run
         uses: cypress-io/github-action@v5
-        with:
-          build: npm run build
-          start: npm start

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,8 +25,7 @@
       "devDependencies": {
         "@graphql-codegen/cli": "^3.3.1",
         "@graphql-codegen/client-preset": "^3.0.1",
-        "cypress": "^12.11.0",
-        "typescript": "^5.0.4"
+        "cypress": "^12.11.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -19818,15 +19817,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
-      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=12.20"
+        "node": ">=4.2.0"
       }
     },
     "node_modules/ua-parser-js": {
@@ -35407,9 +35407,10 @@
       }
     },
     "typescript": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
-      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw=="
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "peer": true
     },
     "ua-parser-js": {
       "version": "0.7.35",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
   "devDependencies": {
     "@graphql-codegen/cli": "^3.3.1",
     "@graphql-codegen/client-preset": "^3.0.1",
-    "cypress": "^12.11.0",
-    "typescript": "^5.0.4"
+    "cypress": "^12.11.0"
   }
 }


### PR DESCRIPTION
## Description:
- This fixes a dependency conflict that was causing errors (we installed TS when we added apollo client), but react scripts handles this for us.
- I changed the CI to only run cypress on `pull request` rather than on `push` (I often push up a few times if I caught a bug or decided to change something before opening a PR, etc) & I don't see a reason for running CI until the PR is open.
- I removed some unneeded options as the options that were at the end of the `main.yml` as the options that were included are the default. I also changed the `runs-on` to pull in the latest instead of specifying which version.


### Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Has This Been Tested Yet?
- [x] Yes
- [ ] No

### Comments or Questions:
- I did this because when I pulled down the work and ran `npm i` there were multiple errors present about conflicting dependencies and looked into it.
