### PR TITLE
Feat/form submission error handling

### DIFF
--- a/src/components/NewConditionPage/DoctorForm/DoctorForm.tsx
+++ b/src/components/NewConditionPage/DoctorForm/DoctorForm.tsx
@@ -16,14 +16,18 @@ export const DoctorForm = ({conditionId}: NewDoctorProps) => {
     category: ''
   });
 
-
-  const handleClick = () => {
-    if (Object.keys(doctorInfo).filter(Boolean).length) {
-      mutateFunction();
+  const handleClick = async () => {
+    const formIsDirty = Object.keys(doctorInfo).filter(Boolean).length;
+    if (formIsDirty) {
+      try { 
+        await mutateFunction();
+      } catch(error) {
+        return;
+      }
       setDoctorInfo({name: '',
-      phone: '',
-      address: '',
-      category: ''
+        phone: '',
+        address: '',
+        category: ''
       });
     }
     history.push('/add-condition/add-health-event');
@@ -51,16 +55,22 @@ export const DoctorForm = ({conditionId}: NewDoctorProps) => {
   `;
 
   const [mutateFunction, {data, loading, error}] = useMutation(CREATE_DOCTOR);
-  if (loading) return (<p>Loading...</p>);
-  if (error) return (<p>Error: {error.message}</p>);
   
   return (
     <section className='add-doctor'>
       <h2>Add a Doctor</h2>
       <form onSubmit={async e => {
         e.preventDefault();
-        await mutateFunction();
-        setDoctorInfo({name: '', phone: '', address: '', category: ''});
+        try { 
+          await mutateFunction();
+        } catch(error) {
+          return;
+        }
+        setDoctorInfo({
+          name: '',
+          phone: '',
+          address: '',
+          category: ''});
       }}>
           <div>
           <label>
@@ -106,7 +116,9 @@ export const DoctorForm = ({conditionId}: NewDoctorProps) => {
         </div>
         <button className='submit-button' type='submit'>Add Another Doctor</button>
       </form>
-      <button onClick={handleClick}>Go to health events</button>
+      <button type='button' onClick={handleClick}>Go to health events</button>
+      {loading ? <p>Loading...</p> : null}
+      {error ? <p>Sorry, there was an error when submitting your form, please try again</p> : null}
     </section>
   );
 }

--- a/src/components/NewConditionPage/HealthEventForm/HealthEventForm.tsx
+++ b/src/components/NewConditionPage/HealthEventForm/HealthEventForm.tsx
@@ -79,7 +79,7 @@ export const HealthEventForm = ({conditionId}: NewEventProps) => {
             <option defaultValue='' hidden>Select health event type:</option>
             <option value='symptom'>Symptom</option>
             <option value='doctor_visit'>Doctor's Visit</option>
-            <option value='other_note'>Other Note</option>
+            <option value='general_note'>Other Note</option>
           </select>
         </label>
         <label>

--- a/src/components/NewConditionPage/HealthEventForm/HealthEventForm.tsx
+++ b/src/components/NewConditionPage/HealthEventForm/HealthEventForm.tsx
@@ -15,9 +15,14 @@ export const HealthEventForm = ({conditionId}: NewEventProps) => {
     note: ''
   });
 
-  const handleClick = () => {
-    if (Object.keys(eventObj).filter(Boolean).length) {
-      mutateFunction();
+  const handleClick = async() => {
+    const formIsDirty = Object.keys(eventObj).filter(Boolean).length;
+    if (formIsDirty) {
+      try { 
+        await mutateFunction();
+      } catch(error) {
+        return;
+      }
       setEventObj({
         category: '',
         date: '',
@@ -47,14 +52,17 @@ export const HealthEventForm = ({conditionId}: NewEventProps) => {
   `;
 
   const [mutateFunction, {data, loading, error}] = useMutation(CREATE_NOTE);
-  if (loading) return (<p>Loading...</p>);
-  if (error) return (<p>Error: {error.message}</p>);
 
   return (
     <section>
+      <h3>Add a health event</h3>
       <form onSubmit={async e => {
         e.preventDefault()
-        await mutateFunction();
+        try { 
+          await mutateFunction();
+        } catch(error) {
+          return;
+        }
         setEventObj({
           category: '',
           date: '',
@@ -92,7 +100,9 @@ export const HealthEventForm = ({conditionId}: NewEventProps) => {
         </label>
         <button>Add New Note</button>
       </form>
-      <button onClick={handleClick}>Finish and Return to Dash</button>
+      <button type='button' onClick={handleClick}>Finish and Return to Dash</button>
+      {loading ? <p>Loading...</p> : null}
+      {error ? <p>Sorry, there was an error when submitting your form, please try again</p> : null}
     </section>
   );
 }

--- a/src/components/NewConditionPage/MedicationForm/MedicationForm.tsx
+++ b/src/components/NewConditionPage/MedicationForm/MedicationForm.tsx
@@ -17,9 +17,15 @@ export const MedicationForm = ({conditionId}: NewMedicationProps) => {
     prescribedBy: ''
   });
 
-  const handleClick = () => {
-    if (Object.keys(medObj).filter(Boolean).length) {
-      mutateFunction();
+  
+  const handleClick = async () => {
+    const formIsDirty = Object.keys(medObj).filter(Boolean).length;
+    if (formIsDirty) {
+      try { 
+        await mutateFunction();
+      } catch(error) {
+        return;
+      }
       setMedObj({
         name : '',
         datePrescribed: '',
@@ -39,7 +45,7 @@ export const MedicationForm = ({conditionId}: NewMedicationProps) => {
         datePrescribed: "${medObj.datePrescribed}"
         dosage: "${medObj.dosage}"
         frequency: "${medObj.frequency}"
-        prescribedBy: "${medObj.prescribedBy}"
+        prescribedBy: 69
       }) {
         medication {
             id
@@ -56,16 +62,18 @@ export const MedicationForm = ({conditionId}: NewMedicationProps) => {
   `;
 
   const [mutateFunction, {data, loading, error}] = useMutation(CREATE_MEDICATION);
-  if (loading || !conditionId) return (<p>Loading...</p>);
-  if (error) return (<p>Error: {error.message}</p>);
-
+  if (!conditionId) return (<p>Loading...</p>);
 
   return (
     <section className='medication-form nav-spacing'>
       <h3>Add New Medications</h3>
       <form className='med-form' onSubmit={async e => {
         e.preventDefault();
-        await mutateFunction();
+        try { 
+          await mutateFunction();
+        } catch(error) {
+          return;
+        }
         setMedObj({
           name : '',
           datePrescribed: '',
@@ -120,7 +128,9 @@ export const MedicationForm = ({conditionId}: NewMedicationProps) => {
         </label>
         <button className='submit-button' type='submit' >Add New Medication</button>
       </form>
-        <button className='f' onClick={handleClick}>Go to Doctor form</button>
+        <button className='f' type='button' onClick={handleClick} disabled={loading}>Go to Doctor form</button>
+        {loading ? <p>Loading...</p> : null}
+        {error ? <p>Sorry, there was an error when submitting your form, please try again</p> : null}
     </section>
   );
 }

--- a/src/components/NewConditionPage/MedicationForm/MedicationForm.tsx
+++ b/src/components/NewConditionPage/MedicationForm/MedicationForm.tsx
@@ -45,7 +45,7 @@ export const MedicationForm = ({conditionId}: NewMedicationProps) => {
         datePrescribed: "${medObj.datePrescribed}"
         dosage: "${medObj.dosage}"
         frequency: "${medObj.frequency}"
-        prescribedBy: 69
+        prescribedBy: "${medObj.prescribedBy}"
       }) {
         medication {
             id

--- a/src/components/NewConditionPage/TitleForm/TitleForm.tsx
+++ b/src/components/NewConditionPage/TitleForm/TitleForm.tsx
@@ -3,50 +3,50 @@ import { useMutation, gql } from '@apollo/client';
 import { useHistory } from 'react-router-dom';
 import './TitleForm.css';
 
-
 type TitleFormProps = {
   userId: number,
   setConditionId: Function
-}
-
+};
 
 export const TitleForm = ({ userId, setConditionId }: TitleFormProps) => {
   const [conditionName, setConditionName] = useState('');
   const history = useHistory();
+
   const CREATE_CONDITION = gql`
-  mutation {
-    createCondition(input: {
-      name: "${conditionName}"
-      userId: ${userId}
-    }) {
-      condition {
-        id
-        name 
+    mutation {
+      createCondition(input: {
+        name: "${conditionName}"
+        userId: ${userId}
+      }) {
+        condition {
+          id
+          name 
+        }
       }
     }
-  }
-  `
-  
+  `;
+
   const [mutateFunction, { data, loading, error }] = useMutation(CREATE_CONDITION);
   const condId = data?.createCondition.condition.id;
 
   useEffect(() => {
     setConditionId(condId);
-  }, [condId])
+  }, [condId, setConditionId]);
 
   useEffect(() => {
     if (condId) history.push('/add-condition/add-medication');
-  }, [condId])
-
-  if (loading) return <p>Loading...</p>
-  if (error) return <p>Error</p>
+  }, [condId]);
 
   return (
     <section className='condition-form nav-spacing'>
       <h3> Add Your Condition</h3>
       <form className='condition-form' onSubmit={async e => {
         e.preventDefault();
-        await mutateFunction();
+        try { 
+          await mutateFunction();
+        } catch(error) {
+          return;
+        }
         setConditionName('');
       }}>
         <label className='med-label'>
@@ -60,7 +60,9 @@ export const TitleForm = ({ userId, setConditionId }: TitleFormProps) => {
             onChange={e => setConditionName(e.target.value)}/>
         </label>
           <button className='submit-button' type='submit'>Submit condition</button>
+          {loading ? <p>Loading...</p> : null}
+          {error ? <p>Sorry, there was an error when submitting your form, please try again</p> : null}
       </form>
     </section>
-  )
+  );
 }


### PR DESCRIPTION
## Description: 
- This adds error handling to all the forms by adding a `<p>` element with a little error message.
- This utilizes a `try catch` when awaiting the promise back from `useMutation` to implement errors
- This moves the loading message into the form 
- This changes the type to button on the buttons outside of the form to prevent the page re-render

### Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Has This Been Tested Yet?
- [X] Yes
- [ ] No

### Comments or Questions:
- Feel free to change what the error message says!
- I did not add a success message, but i think it would be very similar to the error tag