### PR TITLE
Feat/date parameters and form feedback

### DIFF
--- a/src/components/NewConditionPage/DoctorForm/DoctorForm.tsx
+++ b/src/components/NewConditionPage/DoctorForm/DoctorForm.tsx
@@ -15,6 +15,7 @@ export const DoctorForm = ({conditionId}: NewDoctorProps) => {
     address: '',
     category: ''
   });
+  const [success, setSuccess] = useState(false);
 
   const handleClick = async () => {
     const formIsDirty = Object.values(doctorInfo).filter(Boolean).length;
@@ -67,7 +68,10 @@ export const DoctorForm = ({conditionId}: NewDoctorProps) => {
           name: '',
           phone: '',
           address: '',
-          category: ''});
+          category: ''
+        });
+        setSuccess(true);
+        setTimeout(setSuccess, 4000, false);
       }}>
         <div>
           <label>
@@ -113,9 +117,10 @@ export const DoctorForm = ({conditionId}: NewDoctorProps) => {
         </div>
         <button className='submit-button' type='submit'>Add Another Doctor</button>
       </form>
-      <button className='submit-button' type='button' onClick={handleClick}>Go to health events</button>
+      <button className='submit-button' type='button' onClick={handleClick} disabled={loading}>Go to health events</button>
       {loading ? <p>Loading...</p> : null}
       {error ? <p>Sorry, there was an error when submitting your form, please try again</p> : null}
+      {success ? <p>Your doctor was successfully added, you can now add another one.</p> : null}
     </section>
   );
 }

--- a/src/components/NewConditionPage/DoctorForm/DoctorForm.tsx
+++ b/src/components/NewConditionPage/DoctorForm/DoctorForm.tsx
@@ -28,9 +28,12 @@ export const DoctorForm = ({conditionId}: NewDoctorProps) => {
           address: doctorInfo.address,
           category: doctorInfo.category
         }
-        await mutateFunction({
+        const data = await mutateFunction({
           variables: { input }
         });
+        if (data?.data?.createDoctor.errors.length) {
+          return;
+        }
       } catch(error) {
         return;
       }
@@ -44,7 +47,8 @@ export const DoctorForm = ({conditionId}: NewDoctorProps) => {
   }
 
   const [mutateFunction, {data, loading, error}] = useMutation(CREATE_DOCTOR);
-  
+  const mutateErrors = data?.createDoctor?.errors;
+
   return (
     <section className='condition-form'>
       <h2>Add a Doctor</h2>
@@ -58,9 +62,12 @@ export const DoctorForm = ({conditionId}: NewDoctorProps) => {
             address: doctorInfo.address,
             category: doctorInfo.category
           }
-          await mutateFunction({
+          const data = await mutateFunction({
             variables: { input }
           });
+          if (data?.data?.createDoctor.errors.length) {
+            return;
+          }
         } catch(error) {
           return;
         }
@@ -120,6 +127,7 @@ export const DoctorForm = ({conditionId}: NewDoctorProps) => {
       <button className='submit-button' type='button' onClick={handleClick} disabled={loading}>Go to health events</button>
       {loading ? <p>Loading...</p> : null}
       {error ? <p>Sorry, there was an error when submitting your form, please try again</p> : null}
+      {mutateErrors?.length ? <p>{mutateErrors}</p> : null}
       {success ? <p>Your doctor was successfully added, you can now add another one.</p> : null}
     </section>
   );

--- a/src/components/NewConditionPage/HealthEventForm/HealthEventForm.tsx
+++ b/src/components/NewConditionPage/HealthEventForm/HealthEventForm.tsx
@@ -13,6 +13,7 @@ export const HealthEventForm = ({conditionId}: NewEventProps) => {
     date: '',
     note: ''
   });
+  const [success, setSuccess] = useState(false);
 
   const handleClick = async() => {
     const formIsDirty = Object.values(eventObj).filter(Boolean).length > 0;
@@ -72,6 +73,8 @@ export const HealthEventForm = ({conditionId}: NewEventProps) => {
           date: '',
           note: ''
         });
+        setSuccess(true);
+        setTimeout(setSuccess, 4000, false);
       }}>
         <h2>Create Event Notes</h2>
         <label>
@@ -103,12 +106,13 @@ export const HealthEventForm = ({conditionId}: NewEventProps) => {
             name='note'
             onChange={e => setEventObj({...eventObj, [e.target.name]: e.target.value })} />
         </label>
-        <button className='submit-button'>Add New Note</button>
+        <button className='submit-button'>Add Another Note</button>
       </form>
-      <button className='submit-button' type='button' onClick={handleClick}>Finish and Return to Dash</button>
+      <button className='submit-button' type='button' onClick={handleClick} disabled={loading}>Finish and Return to Dash</button>
       {loading ? <p>Loading...</p> : null}
       {error ? <p>Sorry, there was an error when submitting your form, please try again</p> : null}
       {mutateErrors?.length ? <p>Please fill out all fields</p> : null}
+      {success ? <p>Your health event was successfully added, you can now add another one.</p> : null}
     </section>
   );
 }

--- a/src/components/NewConditionPage/HealthEventForm/HealthEventForm.tsx
+++ b/src/components/NewConditionPage/HealthEventForm/HealthEventForm.tsx
@@ -4,6 +4,7 @@ import { useMutation } from '@apollo/client';
 import { NewEventProps } from '../../../types';
 import './HealthEventForm.css';
 import { CREATE_NOTE } from '../../../gql-queries';
+import { DateTime } from 'luxon';
 
 export const HealthEventForm = ({conditionId}: NewEventProps) => {
   const history = useHistory();
@@ -41,11 +42,11 @@ export const HealthEventForm = ({conditionId}: NewEventProps) => {
     history.push('/user-dashboard');
   }
 
+  const currentDate = DateTime.now().toISODate() as string
   const [mutateFunction, {data, loading, error}] = useMutation(CREATE_NOTE);
   const mutateErrors = data?.createHealthEvent.errors;
   
   return (
-    <>
     <section className='condition-form'>
       <h3>Add a health event</h3>
       <form onSubmit={async e => {
@@ -91,6 +92,7 @@ export const HealthEventForm = ({conditionId}: NewEventProps) => {
             type='date' 
             value={eventObj.date} 
             name='date'
+            max={currentDate}
             onChange={e => setEventObj({...eventObj, [e.target.name]: e.target.value })} />
         </label>
         <label>
@@ -108,6 +110,5 @@ export const HealthEventForm = ({conditionId}: NewEventProps) => {
       {error ? <p>Sorry, there was an error when submitting your form, please try again</p> : null}
       {mutateErrors?.length ? <p>Please fill out all fields</p> : null}
     </section>
-    </>
   );
 }

--- a/src/components/NewConditionPage/MedicationForm/MedicationForm.tsx
+++ b/src/components/NewConditionPage/MedicationForm/MedicationForm.tsx
@@ -29,9 +29,12 @@ export const MedicationForm = ({conditionId}: NewMedicationProps) => {
           frequency: medObj.frequency,
           prescribedBy: medObj.prescribedBy
         }
-        await mutateFunction({
+        const data = await mutateFunction({
           variables: { input }
         });
+        if (data?.data?.createMedication.errors.length) {
+          return;
+        }
       } catch(error) {
         return;
       }
@@ -49,6 +52,8 @@ export const MedicationForm = ({conditionId}: NewMedicationProps) => {
   const currentDate = DateTime.now().toISODate() as string
 
   const [mutateFunction, {data, loading, error}] = useMutation(CREATE_MEDICATION);
+  const mutateErrors = data?.createMedication?.errors;
+
   if (!conditionId) return (<p>Loading...</p>);
 
   return (
@@ -65,9 +70,12 @@ export const MedicationForm = ({conditionId}: NewMedicationProps) => {
             frequency: medObj.frequency,
             prescribedBy: medObj.prescribedBy
           }
-          await mutateFunction({
+          const data = await mutateFunction({
             variables: { input }
           });
+          if (data?.data?.createMedication.errors.length) {
+            return;
+          }
         } catch(error) {
           return;
         }
@@ -131,6 +139,7 @@ export const MedicationForm = ({conditionId}: NewMedicationProps) => {
       <button className='submit-button' type='button' onClick={handleClick} disabled={loading}>Go to Doctor form</button>
         {loading ? <p>Loading...</p> : null}
         {error ? <p>Sorry, there was an error when submitting your form, please try again</p> : null}
+        {mutateErrors?.length ? <p>{mutateErrors}</p> : null}
         {success ? <p>Your medication was successfully added, you can now add another one.</p> : null}
     </section>
   );

--- a/src/components/NewConditionPage/MedicationForm/MedicationForm.tsx
+++ b/src/components/NewConditionPage/MedicationForm/MedicationForm.tsx
@@ -3,6 +3,7 @@ import { useMutation, gql } from '@apollo/client';
 import { useHistory } from 'react-router-dom';
 import { NewMedicationProps } from '../../../types';
 import { CREATE_MEDICATION } from '../../../gql-queries';
+import { DateTime } from 'luxon';
 import './MedicationForm.css';
 
 export const MedicationForm = ({conditionId}: NewMedicationProps) => {
@@ -44,6 +45,8 @@ export const MedicationForm = ({conditionId}: NewMedicationProps) => {
     }
     history.push('/add-condition/add-doctor');
   }
+
+  const currentDate = DateTime.now().toISODate() as string
 
   const [mutateFunction, {data, loading, error}] = useMutation(CREATE_MEDICATION);
   if (!conditionId) return (<p>Loading...</p>);
@@ -91,6 +94,7 @@ export const MedicationForm = ({conditionId}: NewMedicationProps) => {
             type='date'
             value={medObj.datePrescribed}
             name='datePrescribed'
+            max={currentDate}
             onChange={e => setMedObj({...medObj, [e.target.name]: e.target.value })}/>
         </label>
         <label className='med-label'>

--- a/src/components/NewConditionPage/MedicationForm/MedicationForm.tsx
+++ b/src/components/NewConditionPage/MedicationForm/MedicationForm.tsx
@@ -15,7 +15,7 @@ export const MedicationForm = ({conditionId}: NewMedicationProps) => {
     frequency: '',
     prescribedBy: ''
   });
-
+  const [success, setSuccess] = useState(false);
   
   const handleClick = async () => {
     const formIsDirty = Object.values(medObj).filter(Boolean).length;
@@ -78,6 +78,8 @@ export const MedicationForm = ({conditionId}: NewMedicationProps) => {
           frequency: '',
           prescribedBy: ''
         });
+        setSuccess(true);
+        setTimeout(setSuccess, 4000, false);
       }}>
         <label className='med-label'>
           What is your medication name?
@@ -124,11 +126,12 @@ export const MedicationForm = ({conditionId}: NewMedicationProps) => {
             placeholder='Prescribed by'
             onChange={e => setMedObj({...medObj, [e.target.name]: e.target.value })}/>
         </label>
-        <button className='submit-button' type='submit' >Add New Medication</button>
+        <button className='submit-button' type='submit' >Add Another Medication</button>
       </form>
       <button className='submit-button' type='button' onClick={handleClick} disabled={loading}>Go to Doctor form</button>
         {loading ? <p>Loading...</p> : null}
         {error ? <p>Sorry, there was an error when submitting your form, please try again</p> : null}
+        {success ? <p>Your medication was successfully added, you can now add another one.</p> : null}
     </section>
   );
 }


### PR DESCRIPTION
## Description:

- This adds a max date for all the date inputs to _only_ allow users to input a med or health event on the current date or in the past
- This adds more error handling to Doctor & Medication forms (since the name **is** required for both)
- This utilizes state for if a med/doc/event was successfully added to the database **when a user clicks "add another med/doc/event" button**
   - This renders a success message under the buttons to let the user know
   - This success message is visible for 4 seconds and then disappears by resetting the state
- This changes the button names to "Add Another Med/Doc/Event" instead of "Add New Med/Doc/Event" since it was confusing

### Type of change:

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Has This Been Tested Yet?
- [X] Yes
- [ ] No


Closes # 16, Closes # 12
